### PR TITLE
BEC-236 Use Node 24 runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,5 @@ inputs:
     required: false
     default: 0
 runs:
-  using: 'node16'
+  using: 'node24'
   main: dist/main.js


### PR DESCRIPTION
Bumps the action runtime from node16 to node24 to clear the GitHub node20-deprecation warning. node24 requires Actions Runner v2.327.1+.